### PR TITLE
edit：修改数据库时区

### DIFF
--- a/src/main/resources/application-localhost.properties
+++ b/src/main/resources/application-localhost.properties
@@ -1,3 +1,3 @@
 mysqlUserName=batch_admin
 mysqlPassword=475D8RU6TYGV
-jdbcUrl=jdbc:log4jdbc:mysql://localhost:3306/batch_admin?zeroDateTimeBehavior=convertToNull
+jdbcUrl=jdbc:log4jdbc:mysql://localhost:3306/batch_admin?zeroDateTimeBehavior=convertToNull&serverTimezone=UTC


### PR DESCRIPTION
MySql服务器时区（继承自系统时区）的格式与mysql连接器所期望的格式不同
在启动项目时会抛出异常，该pr指定时区：&serverTimezone=UTC